### PR TITLE
Support styled function components

### DIFF
--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch } from 'react-native';
+import { Switch, View, ViewProps } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
 import { styled, css } from './styled';
@@ -43,6 +43,8 @@ export default function Example({
         </Rect>
 
         <Box2 />
+
+        <FunctionBox />
       </Wrapper>
 
       <StatusBar style="auto" />
@@ -70,6 +72,18 @@ const Box2 = styled(Box, {
   size: 100,
   borderRadius: '$lg',
 });
+
+const FunctionBox = styled(
+  ({ children, ...props }: ViewProps & { children: React.ReactNode }) => (
+    <View {...props}>{children}</View>
+  ),
+  {
+    backgroundColor: 'blue',
+    marginTop: '$2',
+    size: 100,
+    borderRadius: '$sm'
+  }
+)
 
 const Rect = styled('View', {
   backgroundColor: '$primary',

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -196,8 +196,8 @@ export function createCss(config = {}) {
 
       if (typeof component === 'string') {
         return createElement(ReactNative[component], componentProps);
-      } else if (typeof component === 'object') {
-        return cloneElement(component, componentProps);
+      } else if (typeof component === 'object' || typeof component === 'function') {
+        return createElement(component, componentProps);
       }
 
       return null;


### PR DESCRIPTION
When trying to use `styled` without the string alias like `styled("View", ...)`, but with an actual component like `styled(View, ...)`, I'm getting this error:

```
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports
```

This is due to a missing check for `typeof component === "function"`. Also, `cloneElement` is used rather than `createElement` after the `typeof component === "object"` check which I assume was to allow using `styled` for `React.memo`'ed components already created by `styled("View", ...)`. Note that `createElement` works with memoized components as well as with any other function or class component.