### PR TITLE
Use PropsWithChildren for non-builtin components

### DIFF
--- a/src/types/react-native.d.ts
+++ b/src/types/react-native.d.ts
@@ -193,5 +193,7 @@ type ReactNativeComponentProps<
 
 export type ReactNativeComponentPropsWithRef<T extends ReactNativeElementType> =
   T extends React.ComponentClass<infer P>
-    ? React.PropsWithoutRef<P> & React.RefAttributes<InstanceType<T>>
+    ? React.PropsWithChildren<
+        React.PropsWithoutRef<P> & React.RefAttributes<InstanceType<T>>
+      >
     : React.PropsWithRef<ReactNativeComponentProps<T>>;


### PR DESCRIPTION
When using `styled(View, ...)` without string alias, the resulting props are missing `children`. This PR adds the prop to all components that are not part of `ReactNativeElements`.