### PR TITLE
Add missing type for useTheme, and Example

### DIFF
--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Switch, View, ViewProps } from 'react-native';
+import { ActivityIndicator, Switch, View, ViewProps } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
-import { styled, css } from './styled';
+import { styled, css, useTheme } from './styled';
 
 export default function Example({
   mode,
@@ -15,36 +15,34 @@ export default function Example({
     <>
       <Wrapper>
         <Switch value={mode === 'dark'} onValueChange={toggleMode} />
+        <RowView>
+          <Button variant="primary">
+            <ButtonText color="white">Hello</ButtonText>
+          </Button>
 
-        <Button variant="primary">
-          <ButtonText color="white">Hello</ButtonText>
-        </Button>
+          <Button variant="secondary">
+            <ButtonText>Hello</ButtonText>
+          </Button>
 
-        <Button variant="secondary" style={{ marginTop: 16 }}>
-          <ButtonText>Hello</ButtonText>
-        </Button>
-
-        <Button
-          variant="secondary"
-          size="small"
-          outlined
-          style={{ marginTop: 16 }}
-        >
-          <ButtonText
-            variant={{ '@phone': 'body', '@tablet': 'title' }}
-            color={{ '@sm': 'primary', '@xl': 'secondary' }}
-          >
-            Hello
-          </ButtonText>
-        </Button>
-
-        <Rect>
-          <Box css={{ backgroundColor: '$secondary', size: 40 }} />
-        </Rect>
-
-        <Box2 />
-
-        <FunctionBox />
+          <Button variant="secondary" size="small" outlined>
+            <ButtonText
+              variant={{ '@phone': 'body', '@tablet': 'title' }}
+              color={{ '@sm': 'primary', '@xl': 'secondary' }}
+            >
+              Hello
+            </ButtonText>
+          </Button>
+        </RowView>
+        <RowView>
+          <Rect>
+            <Box css={{ backgroundColor: '$secondary', size: 40 }} />
+          </Rect>
+          <Box2 />
+          <FunctionBox />
+        </RowView>
+        <RowView>
+          <UseThemeExample />
+        </RowView>
       </Wrapper>
 
       <StatusBar style="auto" />
@@ -64,6 +62,12 @@ const Wrapper = styled('View', {
   ...someStyles,
 });
 
+const RowView = styled('View', {
+  flexDirection: 'row',
+  alignItems: 'center',
+  marginTop: '$3',
+});
+
 const Box = styled('View', {});
 
 const Box2 = styled(Box, {
@@ -81,9 +85,9 @@ const FunctionBox = styled(
     backgroundColor: 'blue',
     marginTop: '$2',
     size: 100,
-    borderRadius: '$sm'
+    borderRadius: '$sm',
   }
-)
+);
 
 const Rect = styled('View', {
   backgroundColor: '$primary',
@@ -179,3 +183,8 @@ const ButtonText = styled('Text', {
     variant: 'body',
   },
 });
+
+const UseThemeExample = () => {
+  const theme = useTheme();
+  return <ActivityIndicator size="small" color={theme.colors?.blue100} />;
+};

--- a/example/src/styled.tsx
+++ b/example/src/styled.tsx
@@ -17,7 +17,7 @@ getDeviceTypeAsync().then((deviceType) => {
   media.tablet = deviceType === DeviceType.TABLET;
 });
 
-const { styled, css, theme, ThemeProvider } = createCss({
+const { styled, css, theme, ThemeProvider, useTheme } = createCss({
   theme: {
     colors: {
       // Palette
@@ -99,9 +99,10 @@ const { styled, css, theme, ThemeProvider } = createCss({
 
 const darkTheme = theme({
   colors: {
+    blue100: '#2eee05',
     background: '$black',
     text: '$white',
   },
 });
 
-export { styled, css, theme, darkTheme, ThemeProvider };
+export { styled, css, theme, darkTheme, useTheme, ThemeProvider };

--- a/src/types/core.d.ts
+++ b/src/types/core.d.ts
@@ -233,6 +233,7 @@ export interface TStyledSheet<
   utils: C;
 
   theme: (theme: Partial<{ [TO in keyof B]: Partial<B[TO]> }>) => ThemeRule;
+  useTheme: () => Partial<{ [TO in keyof B]: Partial<B[TO]> }>;
   ThemeProvider: React.FunctionComponent<{ theme?: ThemeRule }>;
 }
 


### PR DESCRIPTION
This PR complements commit c427aed and fixes #2

* Add missing type for `useTheme` 
* Add example for how to use this hook
```
const UseThemeExample = () => {
  const theme = useTheme();
  return <ActivityIndicator size="small" color={theme.colors?.blue100} />;
};
```
* Organize Example layout

![image](https://user-images.githubusercontent.com/87080313/128252668-e2e73379-a394-4ca5-ae8d-128a519f5810.png)

![image](https://user-images.githubusercontent.com/87080313/128252713-d3332edb-2c34-4b0b-914e-5f38ebbe1bbd.png)


