### PR TITLE
[Feature] Add support for Scale prefixed tokens

### DIFF
--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -48,7 +48,7 @@ export default function Example({
           }}
         >
           <EqualPadding>
-            <View style={{ width: 20, height: 20, backgroundColor: 'red' }} />
+            <Box css={{ width: '$space$4', height: '$space$4', backgroundColor: '$blue900' }} />
           </EqualPadding>
         </RowView>
       </Wrapper>

--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -48,7 +48,13 @@ export default function Example({
           }}
         >
           <EqualPadding>
-            <Box css={{ width: '$space$4', height: '$space$4', backgroundColor: '$blue900' }} />
+            <Box
+              css={{
+                width: '$space$4',
+                height: '$space$4',
+                backgroundColor: '$blue900',
+              }}
+            />
           </EqualPadding>
         </RowView>
       </Wrapper>

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -192,6 +192,7 @@ export function createCss(config = {}) {
             config,
           })
         : {};
+
       const componentProps = {
         ...props,
         style: [

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -192,7 +192,6 @@ export function createCss(config = {}) {
             config,
           })
         : {};
-
       const componentProps = {
         ...props,
         style: [

--- a/src/internals/utils.js
+++ b/src/internals/utils.js
@@ -86,9 +86,12 @@ export function processStyles({ styles, theme, config }) {
         ...processStyles({ styles: utils[key](config)(val), theme, config }),
       };
     } else if (typeof val === 'string' && val.indexOf('$') !== -1) {
-      const token = val.replace('$', '');
-
-      if (key in (themeMap.colors || {}) && theme?.colors) {
+      const arr = val.split('$');
+      const token = arr.pop();
+      const scaleName = arr.pop();
+      if (scaleName && theme[scaleName]) {
+        acc[key] = theme[scaleName][token];
+      } else if (key in (themeMap.colors || {}) && theme?.colors) {
         acc[key] = theme.colors[token];
       } else if (key in (themeMap.radii || {}) && theme?.radii) {
         acc[key] = theme.radii[token];


### PR DESCRIPTION
Stitches core supports overwriting the theme mapping via scale-prefixed tokens (See: https://stitches.dev/docs/tokens#scale-prefixed-tokens)

```
const SomeView= styled('View', {
  // margin* props default to `space` scale in the theme, but here we get the value from `sizes` scale instead
  marginTop: '$sizes$1',

  // width defaults to `sizes` scale in the theme, but here we get the value from `space` scale instead 
  width: '$space$4'
});
```

![image](https://user-images.githubusercontent.com/9648559/128745121-0d3f84f8-c8f7-4afe-bbc7-3562dab32d1a.png)
