### PR TITLE
Fix: Variant props being passed as is to native components

### DIFF
--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -230,9 +230,14 @@ export function createStitches(config = {}) {
         attrsProps = attrsFn({ ...props, theme: theme.values });
       }
 
+      const propsWithoutVariant = { ...props };
+      for (const variantKey of Object.keys(variants)) {
+        delete propsWithoutVariant[variantKey];
+      }
+
       const componentProps = {
         ...attrsProps,
-        ...props,
+        ...propsWithoutVariant,
         style: allStyles,
         ref,
       };


### PR DESCRIPTION
This PR fixes variant props being passed to native components.

For e.g.,

```
const Flex = styled('View', {
	variants: {
		direction: {
			row: { ... },
			col: { ... }
		}
	}
})

...

<Flex direction="row" />
```

Results in the following issue in iOS
![Screenshot 2022-05-12 at 18 46 41](https://user-images.githubusercontent.com/45140148/168084237-0054d46f-a445-4f41-aa90-2b58a44a3a39.png)
