### PR TITLE
Fix css prop inline media style applied

### DIFF
--- a/example/src/Example.tsx
+++ b/example/src/Example.tsx
@@ -26,7 +26,16 @@ export default function Example() {
               <Heading heading="h3">Heading</Heading>
               <Heading heading="h4">Heading</Heading>
               <Heading heading="h5">Heading</Heading>
-              <Heading underlined>Compound Variants</Heading>
+              <Heading
+                // NOTE: test inline media style.
+                // marginTopRem util function turns media style.
+                css={{
+                  marginTopRem: 1,
+                }}
+                underlined
+              >
+                Compound Variants
+              </Heading>
               <Heading underlined heading="h2">
                 Heading
               </Heading>

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -207,13 +207,18 @@ export function createStitches(config = {}) {
           .filter(Boolean);
       }
 
-      const cssStyles = props.css
+      let cssStyles = props.css
         ? utils.processStyles({
             styles: props.css || {},
             theme: theme.values,
             config,
           })
         : {};
+
+      if (cssStyles && breakpoint in cssStyles) {
+        // WARNING: lodash merge modifies the first argument reference or skips if object is frozen.
+        cssStyles = merge({}, cssStyles, cssStyles[breakpoint]);
+      }
 
       const mediaStyle = styleSheet.base[breakpoint] || {};
 


### PR DESCRIPTION
This PR fixes css prop passed from parent component doesn't interpret media prop.

Now,
```tsx
<Component
  css={{
    '@bp1': {
      margin: 1
    }
  }}
/>
```
is valid as css type defined.