### PR TITLE
Fix css type is different from web 

### DIFF
--- a/example/src/type-test.tsx
+++ b/example/src/type-test.tsx
@@ -1,0 +1,9 @@
+import { styled, css } from './styles';
+
+const View = styled('View', {});
+
+const csstest = css({
+  fontSize: 16,
+});
+
+export const Test = <View css={csstest} />;

--- a/src/types/stitches.d.ts
+++ b/src/types/stitches.d.ts
@@ -124,12 +124,7 @@ export default interface Stitches<
                   : unknown;
               };
       }
-    ): StyledComponent.CssComponent<
-      StyledComponent.StyledComponentType<Composers>,
-      StyledComponent.StyledComponentProps<Composers>,
-      Media,
-      CSS
-    >;
+    ): CSS;
   }; // TODO: `variants` inside `css` break TS...
   styled: {
     <


### PR DESCRIPTION
I noticed css type doesn't match styled component css prop.  So in [this example](https://github.com/Temzasse/stitches-native#using-css-helper) type error occurs.
![スクリーンショット 2022-11-08 14 09 07](https://user-images.githubusercontent.com/7004725/200482768-1a18bede-7879-475a-bbdc-38ccd2d8a3d7.png)

This type is css object but, defined as function like component with some merged props, maybe it's copied from stitches for web.
Stitches native's css returns css type generated by createStitches, so I fix the type as it is.
